### PR TITLE
Dodaj przyciski "Wróć" i "Zamknij grę" na ekranach startowych

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -476,30 +476,38 @@ if __name__ == "__main__":
     screen = pygame.display.set_mode((WIDTH, HEIGHT))
     pygame.display.set_caption("Math RPG")
 
-    current_user = user_selection_screen(screen)
-    selection = start_screen(screen, current_user)
+    while True:
+        current_user = user_selection_screen(screen)
 
-    if selection == "new":
-        player_character = choose_character()
-        player = Player(WIDTH // 2 // grid_size * grid_size + 40, HEIGHT // 2 // grid_size * grid_size + 40,
-                        player_character)
-        main(player, current_user)
-    else:
-        state = load_game_state(current_user)
-        if state is not None:
-            show_message("Załadowano grę!")
-            player_character = state["player"]["character"]
-            player = Player(WIDTH // 2 // grid_size * grid_size + 40, HEIGHT // 2 // grid_size * grid_size + 40,
-                            player_character)
-            player.x = state["player"]["x"]
-            player.y = state["player"]["y"]
-            player.health = state["player"]["health"]
-            player.xp = state["player"]["xp"]
-            player.coins = state["player"]["coins"]
-            player.character = state["player"]["character"]
-            player.inventory = state["player"]["inventory"]
-            world_position = state["world_position"]
-            selected_land = state["selected_land"]
-            completed_realms = set(state["completed_realms"])
+        while True:
+            selection = start_screen(screen, current_user)
 
-            main(player, current_user, world_position, selected_land, completed_realms)
+            if selection == "back":
+                break
+
+            if selection == "new":
+                player_character = choose_character()
+                player = Player(WIDTH // 2 // grid_size * grid_size + 40, HEIGHT // 2 // grid_size * grid_size + 40,
+                                player_character)
+                main(player, current_user)
+                break
+
+            state = load_game_state(current_user)
+            if state is not None:
+                show_message("Załadowano grę!")
+                player_character = state["player"]["character"]
+                player = Player(WIDTH // 2 // grid_size * grid_size + 40, HEIGHT // 2 // grid_size * grid_size + 40,
+                                player_character)
+                player.x = state["player"]["x"]
+                player.y = state["player"]["y"]
+                player.health = state["player"]["health"]
+                player.xp = state["player"]["xp"]
+                player.coins = state["player"]["coins"]
+                player.character = state["player"]["character"]
+                player.inventory = state["player"]["inventory"]
+                world_position = state["world_position"]
+                selected_land = state["selected_land"]
+                completed_realms = set(state["completed_realms"])
+
+                main(player, current_user, world_position, selected_land, completed_realms)
+                break

--- a/src/start.py
+++ b/src/start.py
@@ -19,13 +19,14 @@ def user_selection_screen(screen):
     font = pygame.font.SysFont(None, 44)
     small_font = pygame.font.SysFont(None, 34)
 
-    create_button = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 140, 440, 60)
+    create_button = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 190, 440, 60)
+    close_game_button = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 110, 440, 60)
     input_box = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 220, 440, 55)
 
     selected_user = None
     input_mode = False
     typed_name = ""
-    message = "Wybierz użytkownika"
+    message = ""
 
     while running:
         users = get_users()
@@ -59,8 +60,15 @@ def user_selection_screen(screen):
         screen.blit(create_text, (create_button.centerx - create_text.get_width() // 2,
                                   create_button.centery - create_text.get_height() // 2))
 
-        info_text = small_font.render(message, True, WHITE)
-        screen.blit(info_text, (WIDTH // 2 - info_text.get_width() // 2, HEIGHT - 70))
+        pygame.draw.rect(screen, RED, close_game_button, border_radius=8)
+        pygame.draw.rect(screen, BLACK, close_game_button, 2, border_radius=8)
+        close_text = small_font.render("Zamknij grę", True, BLACK)
+        screen.blit(close_text, (close_game_button.centerx - close_text.get_width() // 2,
+                                 close_game_button.centery - close_text.get_height() // 2))
+
+        if message:
+            info_text = small_font.render(message, True, WHITE)
+            screen.blit(info_text, (WIDTH // 2 - info_text.get_width() // 2, HEIGHT - 40))
 
         pygame.display.flip()
         clock.tick(30)
@@ -79,6 +87,9 @@ def user_selection_screen(screen):
                         selected_user = typed_name.strip()
                         typed_name = ""
                         input_mode = False
+                elif close_game_button.collidepoint(event.pos):
+                    pygame.quit()
+                    exit()
                 else:
                     for btn, user in user_buttons:
                         if btn.collidepoint(event.pos):
@@ -109,6 +120,7 @@ def start_screen(screen, user_name):
 
     new_game_button = pygame.Rect(WIDTH // 2 - 170, HEIGHT // 2 - 70, 340, 60)
     load_game_button = pygame.Rect(WIDTH // 2 - 170, HEIGHT // 2 + 10, 340, 60)
+    back_button = pygame.Rect(WIDTH // 2 - 170, HEIGHT // 2 + 90, 340, 60)
 
     while running:
         screen.blit(background_image, (0, 0))
@@ -127,6 +139,11 @@ def start_screen(screen, user_name):
         screen.blit(load_game_text, (load_game_button.centerx - load_game_text.get_width() // 2,
                                      load_game_button.centery - load_game_text.get_height() // 2))
 
+        pygame.draw.rect(screen, RED, back_button)
+        back_text = font.render("Wróć", True, BLACK)
+        screen.blit(back_text, (back_button.centerx - back_text.get_width() // 2,
+                                back_button.centery - back_text.get_height() // 2))
+
         if not load_enabled:
             no_save_text = small_font.render("Brak zapisu dla wybranego użytkownika", True, WHITE)
             screen.blit(no_save_text, (WIDTH // 2 - no_save_text.get_width() // 2, HEIGHT // 2 + 90))
@@ -143,3 +160,5 @@ def start_screen(screen, user_name):
                     return "new"
                 elif load_game_button.collidepoint(event.pos) and load_enabled:
                     return "load"
+                elif back_button.collidepoint(event.pos):
+                    return "back"

--- a/src/start.py
+++ b/src/start.py
@@ -21,7 +21,7 @@ def user_selection_screen(screen):
 
     create_button = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 190, 440, 60)
     close_game_button = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 110, 440, 60)
-    input_box = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 220, 440, 55)
+    input_box = pygame.Rect(WIDTH // 2 - 220, HEIGHT - 260, 440, 55)
 
     selected_user = None
     input_mode = False


### PR DESCRIPTION
### Motivation
- Ułatwić nawigację na ekranach startowych poprzez dodanie możliwości powrotu oraz zamknięcia aplikacji bez wchodzenia do gry.
- Usunąć zbędny, stały komunikat na dole ekranu wyboru użytkownika i pokazywać go tylko gdy jest rzeczywista treść do wyświetlenia.

### Description
- Dodano przycisk `Zamknij grę` na ekranie wyboru użytkownika w `src/start.py` oraz przesunięto układ przycisków, aby zmieścić nowy element.
- Zmieniono domyślny tekst dolnego komunikatu na pusty i renderowanie komunikatu wykonuje się tylko gdy `message` ma treść w `user_selection_screen` w `src/start.py`.
- Dodano przycisk `Wróć` w `start_screen` w `src/start.py`, który zwraca wartość `"back"` po kliknięciu.
- Zaktualizowano pętlę startową w `src/main.py`, aby obsługiwała powrót (`"back"`) do ekranu wyboru użytkownika oraz zainicjowanie nowej/załadowanej gry w pętli.

### Testing
- Skompilowano zmodyfikowane pliki poleceniem `python -m py_compile src/start.py src/main.py` i kompilacja zakończyła się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a75e8531f4832fab062865f8dae923)